### PR TITLE
chore: add Dependabot for GitHub Actions and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
Add Dependabot configuration to automatically update dependencies:

- **GitHub Actions**: Weekly checks for workflow action updates
- **Docker**: Weekly checks for base image updates

This will help keep the project up-to-date and avoid future deprecation warnings.